### PR TITLE
fix tab close button gradient effect on hover

### DIFF
--- a/styles/atom-no-tab-close-button.less
+++ b/styles/atom-no-tab-close-button.less
@@ -3,5 +3,5 @@
 }
 
 .tab-bar .tab:hover .title {
-	-webkit-mask-position: 0 0 !important;
+	-webkit-mask: inherit;
 }


### PR DESCRIPTION
On my mac, the tab still has a gradient effect when I mouseover it.
This change removes the effect.