### PR TITLE
Show modified dot

### DIFF
--- a/styles/atom-no-tab-close-button.less
+++ b/styles/atom-no-tab-close-button.less
@@ -1,7 +1,11 @@
 .tab-bar .tab .close-icon {
-	display: none !important;
+	pointer-events: none;
 }
 
-.tab-bar .tab:hover .title {
-	-webkit-mask-position: 0 0 !important;
+.tab-bar .tab .close-icon::before {
+	content: ""
+}
+
+.tab-bar .tab.modified:hover .close-icon::before {
+	content: "\f052";
 }


### PR DESCRIPTION
Hi there! Thanks for making this plugin, I hated accidentally hitting the close buttons!

I started missing the little blue 'unsaved changes / document modified' dot though.

I propose these changes which still hides the close 'x' but shows the dot.